### PR TITLE
feat: Freibetrag-Monatswert in Konto-Karte anzeigen

### DIFF
--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -159,14 +159,19 @@ export default function Accounts() {
                       <div className="text-xs text-gray-500">{account.description}</div>
                     )}
                     {hasFreibetrag && (
-                      <div className={`text-xs mt-0.5 ${fbExpired ? "text-red-400" : "text-gray-400"}`}>
-                        Freibetrag: {eur(account.freibetrag!)}/Jahr
-                        {account.freibetragYear != null
-                          ? fbExpired
-                            ? ` (abgelaufen ${account.freibetragYear})`
-                            : ` (bis ${account.freibetragYear})`
-                          : " (unbefristet)"}
-                      </div>
+                      <>
+                        <div className={`text-xs mt-0.5 ${fbExpired ? "text-red-400" : "text-gray-400"}`}>
+                          Freibetrag: {eur(account.freibetrag!)} / Jahr
+                          {" "}(= {eur(account.freibetrag! / 12)} / Monat)
+                        </div>
+                        <div className={`text-xs ${fbExpired ? "text-red-400" : "text-gray-500"}`}>
+                          {account.freibetragYear != null
+                            ? fbExpired
+                              ? `abgelaufen ${account.freibetragYear}`
+                              : `bis ${account.freibetragYear}`
+                            : "unbefristet"}
+                        </div>
+                      </>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Konto-Karte zeigt jetzt neben dem Jahresbetrag den monatlichen Äquivalentwert: `Freibetrag: 1.000,00 € / Jahr (= 83,33 € / Monat)`
- Ablaufjahr-Anzeige (bis YYYY / unbefristet / abgelaufen) bleibt als zweite Zeile erhalten

Closes #11

## Test plan
- [ ] Konto mit Freibetrag anlegen → Karte zeigt Jahres- und Monatswert
- [ ] Konto mit Ablaufjahr → zweite Zeile zeigt `bis YYYY`
- [ ] Konto ohne Ablaufjahr → zweite Zeile zeigt `unbefristet`
- [ ] Abgelaufenes Konto → beide Zeilen in Rot

🤖 Generated with [Claude Code](https://claude.com/claude-code)