### PR TITLE
feat: budget limits per category with dashboard progress bars

### DIFF
--- a/server/db/postgres.ts
+++ b/server/db/postgres.ts
@@ -61,6 +61,8 @@ export async function createPostgresAdapter(
   const client = await pool.connect();
   try {
     await client.query(SCHEMA);
+    // Migrations for existing databases
+    try { await client.query("ALTER TABLE categories ADD COLUMN IF NOT EXISTS budget_limit DOUBLE PRECISION DEFAULT NULL"); } catch { /* already exists */ }
     console.log(`[DB] PostgreSQL connected: ${url.replace(/\/\/.*@/, "//***@")}`);
   } finally {
     client.release();

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -63,6 +63,7 @@ export function createSqliteAdapter(dbPath?: string): DbAdapter {
   try { db.exec("ALTER TABLE expense_items ADD COLUMN end_date TEXT DEFAULT NULL"); } catch { /* already exists */ }
   try { db.exec("ALTER TABLE accounts ADD COLUMN freibetrag REAL DEFAULT NULL"); } catch { /* already exists */ }
   try { db.exec("ALTER TABLE accounts ADD COLUMN freibetrag_year INTEGER DEFAULT NULL"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE categories ADD COLUMN budget_limit REAL DEFAULT NULL"); } catch { /* already exists */ }
 
   console.log(`[DB] SQLite connected: ${resolvedPath}`);
 

--- a/server/routes/categories.ts
+++ b/server/routes/categories.ts
@@ -13,20 +13,21 @@ router.get("/", async (_req, res) => {
       name: r.name,
       color: r.color,
       icon: r.icon || undefined,
+      budget: r.budget_limit ?? null,
     }))
   );
 });
 
 // POST /api/categories
 router.post("/", async (req, res) => {
-  const { name, color, icon } = req.body;
+  const { name, color, icon, budget } = req.body;
   if (!name || !color) {
     return res.status(400).json({ error: "name and color are required" });
   }
   const db = await getDb();
   const result = await db.run(
-    "INSERT INTO categories (name, color, icon) VALUES (?, ?, ?)",
-    [name, color, icon || null]
+    "INSERT INTO categories (name, color, icon, budget_limit) VALUES (?, ?, ?, ?)",
+    [name, color, icon || null, budget ?? null]
   );
   res.status(201).json({ id: result.lastId });
 });
@@ -34,7 +35,7 @@ router.post("/", async (req, res) => {
 // PATCH /api/categories/:id
 router.patch("/:id", async (req, res) => {
   const { id } = req.params;
-  const { name, color, icon } = req.body;
+  const { name, color, icon, budget } = req.body;
 
   const db = await getDb();
   const { rows } = await db.query("SELECT id FROM categories WHERE id = ?", [id]);
@@ -46,6 +47,7 @@ router.patch("/:id", async (req, res) => {
   if (name !== undefined) { fields.push("name = ?"); values.push(name); }
   if (color !== undefined) { fields.push("color = ?"); values.push(color); }
   if (icon !== undefined) { fields.push("icon = ?"); values.push(icon || null); }
+  if (budget !== undefined) { fields.push("budget_limit = ?"); values.push(budget ?? null); }
 
   if (fields.length === 0) return res.status(400).json({ error: "No fields to update" });
 

--- a/server/routes/summary.ts
+++ b/server/routes/summary.ts
@@ -81,10 +81,14 @@ router.get("/", async (_req, res) => {
     const share = totalMonthlyExpenses > 0 ? (monthly / totalMonthlyExpenses) * 100 : 0;
 
     return {
-      category: { id: cat.id, name: cat.name, color: cat.color },
+      category: { id: cat.id, name: cat.name, color: cat.color,
+                  budget: cat.budget_limit ?? null },
       monthly,
       share,
       itemCount: catExp.length,
+      pctBudget: cat.budget_limit > 0
+        ? (monthly / cat.budget_limit) * 100
+        : null,
     };
   });
 

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -7,6 +7,7 @@ type Category = {
   name: string;
   color: string;
   icon?: string;
+  budget?: number | null;
 };
 
 const PRESET_COLORS = [
@@ -19,7 +20,7 @@ export default function Categories() {
 
   const [showModal, setShowModal] = useState(false);
   const [editId, setEditId] = useState<number | null>(null);
-  const [form, setForm] = useState({ name: "", color: "#3b82f6", icon: "" });
+  const [form, setForm] = useState({ name: "", color: "#3b82f6", icon: "", budget: "" });
 
   if (!categories) {
     return (
@@ -30,13 +31,14 @@ export default function Categories() {
   }
 
   function openAdd() {
-    setForm({ name: "", color: "#3b82f6", icon: "" });
+    setForm({ name: "", color: "#3b82f6", icon: "", budget: "" });
     setEditId(null);
     setShowModal(true);
   }
 
   function openEdit(cat: Category) {
-    setForm({ name: cat.name, color: cat.color, icon: cat.icon ?? "" });
+    setForm({ name: cat.name, color: cat.color, icon: cat.icon ?? "",
+              budget: cat.budget != null ? String(cat.budget) : "" });
     setEditId(cat.id);
     setShowModal(true);
   }
@@ -47,6 +49,7 @@ export default function Categories() {
       name: form.name.trim(),
       color: form.color,
       icon: form.icon.trim() || undefined,
+      budget: form.budget ? parseFloat(form.budget) : null,
     };
     if (editId) {
       await api.patch(`/categories/${editId}`, payload);
@@ -106,6 +109,11 @@ export default function Categories() {
                   <div className="font-semibold text-white">{cat.name}</div>
                   {cat.icon && (
                     <div className="text-xs text-gray-500">{cat.icon}</div>
+                  )}
+                  {cat.budget != null && cat.budget > 0 && (
+                    <div className="text-xs text-gray-500 mt-0.5">
+                      Budget: {cat.budget.toLocaleString("de-DE", { style: "currency", currency: "EUR" })} / Monat
+                    </div>
                   )}
                 </div>
               </div>
@@ -183,6 +191,21 @@ export default function Categories() {
                   />
                 ))}
               </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-xs text-gray-400 font-medium">
+                Monatsbudget € (optional)
+              </label>
+              <input
+                type="number"
+                value={form.budget}
+                onChange={(e) => setForm((f) => ({ ...f, budget: e.target.value }))}
+                className="input"
+                placeholder="z.B. 200"
+                step="0.01"
+                min="0"
+              />
             </div>
 
             <div className="flex gap-3 pt-2">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -34,10 +34,11 @@ type Summary = {
     freibetragMonthly: number;
   }[];
   byCategory: {
-    category: { id: number; name: string; color: string };
+    category: { id: number; name: string; color: string; budget?: number | null };
     monthly: number;
     share: number;
     itemCount: number;
+    pctBudget: number | null;
   }[];
   expenses: {
     id: number;
@@ -290,13 +291,14 @@ export default function Dashboard() {
               <th className="text-right px-4 py-3 text-gray-400 font-medium">Monatlich</th>
               <th className="text-right px-4 py-3 text-gray-400 font-medium">Jährlich</th>
               <th className="text-right px-4 py-3 text-gray-400 font-medium">Anteil</th>
+              <th className="text-right px-4 py-3 text-gray-400 font-medium">Budget</th>
             </tr>
           </thead>
           <tbody>
             {[...summary.byCategory]
               .filter((c) => c.monthly > 0)
               .sort((a, b) => b.monthly - a.monthly)
-              .map(({ category, monthly, share }) => (
+              .map(({ category, monthly, share, pctBudget }) => (
                 <tr
                   key={category.id}
                   className="border-b border-gray-800/50 hover:bg-gray-800/30"
@@ -327,6 +329,26 @@ export default function Dashboard() {
                         {pct(share)}
                       </span>
                     </div>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {category.budget != null ? (() => {
+                      const p = pctBudget ?? 0;
+                      const barColor = p >= 100 ? "bg-red-500" : p >= 80 ? "bg-yellow-400" : "bg-emerald-500";
+                      const valColor = p >= 100 ? "text-red-400" : p >= 80 ? "text-yellow-400" : "text-emerald-400";
+                      return (
+                        <div className="flex flex-col items-end gap-1">
+                          <span className={`text-xs ${valColor}`}>
+                            {eur(monthly)} / {eur(category.budget!)}
+                          </span>
+                          <div className="w-24 bg-gray-800 rounded-full h-1.5">
+                            <div
+                              className={`h-1.5 rounded-full transition-all ${barColor}`}
+                              style={{ width: `${Math.min(p, 100)}%` }}
+                            />
+                          </div>
+                        </div>
+                      );
+                    })() : <span className="text-gray-600 text-xs">–</span>}
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- New optional `budget_limit` field on `categories` table (SQLite + PostgreSQL migration)
- Categories page: budget input field in the edit/add modal; set value shown on category card
- Dashboard: new **Budget** column in the category table showing `spent / budget` with a color-coded progress bar (green → yellow at 80% → red at 100%)
- Categories without a budget show "–"

Closes #3

## Test plan
- [ ] Kategorien → Kategorie bearbeiten → Budget setzen → Karte zeigt "Budget: X€ / Monat"
- [ ] Dashboard → Kategorientabelle → Budget-Spalte mit Fortschrittsbalken sichtbar
- [ ] Ausgaben < 80% Budget → grüner Balken
- [ ] Ausgaben > 80% Budget → gelber Balken
- [ ] Ausgaben > 100% Budget → roter Balken
- [ ] Kategorie ohne Budget → zeigt "–"

🤖 Generated with [Claude Code](https://claude.com/claude-code)