### PR TITLE
feat: interest rate and validity period per account

### DIFF
--- a/server/db/postgres.ts
+++ b/server/db/postgres.ts
@@ -63,6 +63,8 @@ export async function createPostgresAdapter(
     await client.query(SCHEMA);
     // Migrations for existing databases
     try { await client.query("ALTER TABLE categories ADD COLUMN IF NOT EXISTS budget_limit DOUBLE PRECISION DEFAULT NULL"); } catch { /* already exists */ }
+    try { await client.query("ALTER TABLE accounts ADD COLUMN IF NOT EXISTS interest_rate DOUBLE PRECISION DEFAULT NULL"); } catch { /* already exists */ }
+    try { await client.query("ALTER TABLE accounts ADD COLUMN IF NOT EXISTS interest_rate_until TEXT DEFAULT NULL"); } catch { /* already exists */ }
     console.log(`[DB] PostgreSQL connected: ${url.replace(/\/\/.*@/, "//***@")}`);
   } finally {
     client.release();

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -64,6 +64,8 @@ export function createSqliteAdapter(dbPath?: string): DbAdapter {
   try { db.exec("ALTER TABLE accounts ADD COLUMN freibetrag REAL DEFAULT NULL"); } catch { /* already exists */ }
   try { db.exec("ALTER TABLE accounts ADD COLUMN freibetrag_year INTEGER DEFAULT NULL"); } catch { /* already exists */ }
   try { db.exec("ALTER TABLE categories ADD COLUMN budget_limit REAL DEFAULT NULL"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE accounts ADD COLUMN interest_rate REAL DEFAULT NULL"); } catch { /* already exists */ }
+  try { db.exec("ALTER TABLE accounts ADD COLUMN interest_rate_until TEXT DEFAULT NULL"); } catch { /* already exists */ }
 
   console.log(`[DB] SQLite connected: ${resolvedPath}`);
 

--- a/server/routes/accounts.ts
+++ b/server/routes/accounts.ts
@@ -16,20 +16,22 @@ router.get("/", async (_req, res) => {
       isDefault: !!r.is_default,
       freibetrag: r.freibetrag ?? null,
       freibetragYear: r.freibetrag_year ?? null,
+      interestRate: r.interest_rate ?? null,
+      interestRateUntil: r.interest_rate_until ?? null,
     }))
   );
 });
 
 // POST /api/accounts
 router.post("/", async (req, res) => {
-  const { name, color, description, isDefault, freibetrag, freibetragYear } = req.body;
+  const { name, color, description, isDefault, freibetrag, freibetragYear, interestRate, interestRateUntil } = req.body;
   if (!name || !color) {
     return res.status(400).json({ error: "name and color are required" });
   }
   const db = await getDb();
   const result = await db.run(
-    "INSERT INTO accounts (name, color, description, is_default, freibetrag, freibetrag_year) VALUES (?, ?, ?, ?, ?, ?)",
-    [name, color, description || null, isDefault ? 1 : 0, freibetrag ?? null, freibetragYear ?? null]
+    "INSERT INTO accounts (name, color, description, is_default, freibetrag, freibetrag_year, interest_rate, interest_rate_until) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    [name, color, description || null, isDefault ? 1 : 0, freibetrag ?? null, freibetragYear ?? null, interestRate ?? null, interestRateUntil ?? null]
   );
   res.status(201).json({ id: result.lastId });
 });
@@ -37,7 +39,7 @@ router.post("/", async (req, res) => {
 // PATCH /api/accounts/:id
 router.patch("/:id", async (req, res) => {
   const { id } = req.params;
-  const { name, color, description, isDefault, freibetrag, freibetragYear } = req.body;
+  const { name, color, description, isDefault, freibetrag, freibetragYear, interestRate, interestRateUntil } = req.body;
 
   const db = await getDb();
   const { rows } = await db.query("SELECT id FROM accounts WHERE id = ?", [id]);
@@ -52,6 +54,8 @@ router.patch("/:id", async (req, res) => {
   if (isDefault !== undefined) { fields.push("is_default = ?"); values.push(isDefault ? 1 : 0); }
   if (freibetrag !== undefined) { fields.push("freibetrag = ?"); values.push(freibetrag ?? null); }
   if (freibetragYear !== undefined) { fields.push("freibetrag_year = ?"); values.push(freibetragYear ?? null); }
+  if (interestRate !== undefined) { fields.push("interest_rate = ?"); values.push(interestRate ?? null); }
+  if (interestRateUntil !== undefined) { fields.push("interest_rate_until = ?"); values.push(interestRateUntil ?? null); }
 
   if (fields.length === 0) return res.status(400).json({ error: "No fields to update" });
 

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -11,6 +11,8 @@ type Account = {
   isDefault: boolean;
   freibetrag?: number | null;
   freibetragYear?: number | null;
+  interestRate?: number | null;
+  interestRateUntil?: string | null;
 };
 
 type AccountSummary = {
@@ -46,6 +48,8 @@ export default function Accounts() {
     description: "",
     freibetrag: "",
     freibetragYear: "",
+    interestRate: "",
+    interestRateUntil: "",
   });
 
   if (!accounts || !summary) {
@@ -63,7 +67,7 @@ export default function Accounts() {
   const currentYear = new Date().getFullYear();
 
   function openAdd() {
-    setForm({ name: "", color: "#3b82f6", description: "", freibetrag: "", freibetragYear: "" });
+    setForm({ name: "", color: "#3b82f6", description: "", freibetrag: "", freibetragYear: "", interestRate: "", interestRateUntil: "" });
     setEditId(null);
     setShowAdd(true);
   }
@@ -75,6 +79,8 @@ export default function Accounts() {
       description: a.description ?? "",
       freibetrag: a.freibetrag != null ? String(a.freibetrag) : "",
       freibetragYear: a.freibetragYear != null ? String(a.freibetragYear) : "",
+      interestRate: a.interestRate != null ? String(a.interestRate) : "",
+      interestRateUntil: a.interestRateUntil ?? "",
     });
     setEditId(a.id);
     setShowAdd(true);
@@ -88,6 +94,8 @@ export default function Accounts() {
       description: form.description || undefined,
       freibetrag: form.freibetrag ? parseFloat(form.freibetrag) : null,
       freibetragYear: form.freibetragYear ? parseInt(form.freibetragYear) : null,
+      interestRate: form.interestRate ? parseFloat(form.interestRate) : null,
+      interestRateUntil: form.interestRateUntil || null,
     };
     if (editId) {
       await api.patch(`/accounts/${editId}`, payload);
@@ -173,6 +181,28 @@ export default function Accounts() {
                         </div>
                       </>
                     )}
+                    {account.interestRate != null && account.interestRate > 0 && (() => {
+                      const today = new Date().toISOString().slice(0, 10);
+                      const until = account.interestRateUntil;
+                      const expired  = !!until && until < today;
+                      const expiring = !expired && !!until &&
+                        new Date(until) <= new Date(Date.now() + 60 * 86_400_000);
+                      const cls = expired ? "text-red-400" : expiring ? "text-yellow-400" : "text-emerald-400";
+                      return (
+                        <>
+                          <div className={`text-xs mt-0.5 ${cls}`}>
+                            Zinsen: {account.interestRate.toLocaleString("de-DE", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} % p.a.
+                          </div>
+                          <div className={`text-xs ${cls}`}>
+                            {until
+                              ? expired
+                                ? `abgelaufen ${new Date(until).toLocaleDateString("de-DE")}`
+                                : `bis ${new Date(until).toLocaleDateString("de-DE")}`
+                              : "unbefristet"}
+                          </div>
+                        </>
+                      );
+                    })()}
                   </div>
                 </div>
                 <div className="flex gap-1">
@@ -291,6 +321,31 @@ export default function Accounts() {
                   placeholder={String(currentYear)}
                   min="2000"
                   max="2100"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label className="text-xs text-gray-400 font-medium">Zinssatz % p.a. (optional)</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  max="100"
+                  value={form.interestRate}
+                  onChange={(e) => setForm((f) => ({ ...f, interestRate: e.target.value }))}
+                  className="input"
+                  placeholder="z.B. 3.50"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs text-gray-400 font-medium">Gültig bis (leer = unbefristet)</label>
+                <input
+                  type="date"
+                  value={form.interestRateUntil}
+                  onChange={(e) => setForm((f) => ({ ...f, interestRateUntil: e.target.value }))}
+                  className="input"
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Jedes Konto kann nun einen optionalen Zinssatz (% p.a.) und ein Ablaufdatum (Laufzeit) speichern
- DB-Migration: `interest_rate REAL` + `interest_rate_until TEXT` (SQLite + PostgreSQL)
- Backend: GET/POST/PATCH geben die neuen Felder korrekt weiter
- Frontend: neues Grid im Bearbeiten-Modal (Zinssatz + Datum-Picker)
- Konto-Karte zeigt Zinsen farbig: grün (aktiv/unbefristet), gelb (läuft in ≤ 60 Tagen ab), rot (abgelaufen)

## Test plan
- [ ] Konto bearbeiten → Zinssatz 3,50 % + Datum weit in der Zukunft → grüne Anzeige
- [ ] Datum auf < 60 Tage setzen → gelbe Warnung
- [ ] Datum auf gestern setzen → rote „abgelaufen"-Anzeige
- [ ] Zinssatz leer lassen → keine Zinsen-Zeile auf der Karte
- [ ] Neues Konto ohne Zinssatz erstellen → keine Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)